### PR TITLE
Update graph-cli version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "gala-subgraph",
-  "version": "0.0.8",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "gala-subgraph",
-      "version": "0.0.8",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@amxx/graphprotocol-utils": "^1.1.0",
         "@openzeppelin/subgraphs": "^0.1.7-1"
       },
       "devDependencies": {
-        "@graphprotocol/graph-cli": "^0.30.0",
+        "@graphprotocol/graph-cli": "^0.30.4",
         "@graphprotocol/graph-ts": "^0.27.0"
       }
     },
@@ -531,9 +531,9 @@
       }
     },
     "node_modules/@graphprotocol/graph-cli": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.30.0.tgz",
-      "integrity": "sha512-dpj3cy6/49+MKcQxtuZoiFVW/GwiFD+2p12I3Ly59vNtO0rxP/PoEXp9T3SRFkcxyFEOD74IGA3mcHOkYi0jDg==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.30.4.tgz",
+      "integrity": "sha512-BZNnkSJBgGIVvSx/cxlep1ytKhvGM1ZUZU/73Lu4yH+lpGQN3UtKjlUzcasHqPEwqyp47OifMHlHxDBm4+CVoQ==",
       "dev": true,
       "dependencies": {
         "assemblyscript": "0.19.10",
@@ -5980,9 +5980,9 @@
       }
     },
     "@graphprotocol/graph-cli": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.30.0.tgz",
-      "integrity": "sha512-dpj3cy6/49+MKcQxtuZoiFVW/GwiFD+2p12I3Ly59vNtO0rxP/PoEXp9T3SRFkcxyFEOD74IGA3mcHOkYi0jDg==",
+      "version": "0.30.4",
+      "resolved": "https://registry.npmjs.org/@graphprotocol/graph-cli/-/graph-cli-0.30.4.tgz",
+      "integrity": "sha512-BZNnkSJBgGIVvSx/cxlep1ytKhvGM1ZUZU/73Lu4yH+lpGQN3UtKjlUzcasHqPEwqyp47OifMHlHxDBm4+CVoQ==",
       "dev": true,
       "requires": {
         "assemblyscript": "0.19.10",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "@openzeppelin/subgraphs": "^0.1.7-1"
   },
   "devDependencies": {
-    "@graphprotocol/graph-cli": "^0.30.0",
+    "@graphprotocol/graph-cli": "^0.30.4",
     "@graphprotocol/graph-ts": "^0.27.0"
   }
 }


### PR DESCRIPTION
Previous version of the cli was updating specVersion. This is the latest.